### PR TITLE
[Fix] ArgumentNullException: Value cannot be null. Parameter name: unityObject

### DIFF
--- a/Runtime/Scripts/Variables/DashVariablesController.cs
+++ b/Runtime/Scripts/Variables/DashVariablesController.cs
@@ -87,6 +87,11 @@ namespace Dash
         
         void ISerializationCallbackReceiver.OnAfterDeserialize()
         {
+            if (this.SafeIsUnityNull())
+            {
+                return;
+            }
+            
             // Debug.Log("OnAfterDeserialize: "+_serializedVariables);
             using (var cachedContext = Cache<DeserializationContext>.Claim())
             {
@@ -115,6 +120,10 @@ namespace Dash
         void ISerializationCallbackReceiver.OnBeforeSerialize()
         {
             // Debug.Log("OnBeforeSerialize");
+            if (this.SafeIsUnityNull())
+            {
+                return;
+            }
             
             using (var cachedContext = Cache<SerializationContext>.Claim())
             {


### PR DESCRIPTION
sometimes, "this" is null due to corrupt/invalid serialized data or the object got destroyed earlier.