### PR TITLE
 Unity 6000.4/6000.5 readiness

### DIFF
--- a/Editor/Scripts/DashEditorConfig.cs
+++ b/Editor/Scripts/DashEditorConfig.cs
@@ -78,19 +78,31 @@ namespace Dash
         public int lastUsedVersion = 0;
         
         public DashGraph enteringPlayModeGraph { get; private set; }
+#if UNITY_6000_4_OR_NEWER
+        private EntityId _enteringPlayModeController;
+#else
         private int _enteringPlayModeController;
+#endif
 
         public DashController enteringPlayModeController
         {
             get
             {
+#if UNITY_6000_4_OR_NEWER
+                var controller = EditorUtility.EntityIdToObject(_enteringPlayModeController);
+#else
                 var controller = EditorUtility.InstanceIDToObject(_enteringPlayModeController);
+#endif
                 return controller is DashController ? (DashController) controller : null;
             }
             set
             {
                 enteringPlayModeGraph = editingGraph;
+#if UNITY_6000_4_OR_NEWER
+                _enteringPlayModeController = value == null ? EntityId.None : value.GetEntityId();
+#else
                 _enteringPlayModeController = value == null ? -1 : value.GetInstanceID();
+#endif
             }
         }
         

--- a/Editor/Scripts/Handlers/DashGraphAssetHandler.cs
+++ b/Editor/Scripts/Handlers/DashGraphAssetHandler.cs
@@ -12,9 +12,15 @@ namespace Dash.Editor
     public class DashGraphAssetHandler
     {
         [OnOpenAsset(1)]
+#if UNITY_6000_5_OR_NEWER
+        public static bool OpenDashGraphEditor(EntityId p_entityId, int p_line)
+        {
+            Object asset = EditorUtility.EntityIdToObject(p_entityId);
+#else
         public static bool OpenDashGraphEditor(int p_instanceID, int p_line)
         {
             Object asset = EditorUtility.InstanceIDToObject(p_instanceID);
+#endif
             if (asset.GetType() == typeof(DashGraph))
             {
                 string path = AssetDatabase.GetAssetPath(asset);

--- a/Runtime/Scripts/Node/NodeModelBase.cs
+++ b/Runtime/Scripts/Node/NodeModelBase.cs
@@ -66,7 +66,11 @@ namespace Dash
                         .Invoke(curExposedRef, new object[] {p_propertyTable});
 
                     var clonedExposedRef = Activator.CreateInstance(exposedRefType);
+#if UNITY_6000_4_OR_NEWER
+                    PropertyName newExposedName = new PropertyName(GUID.Generate().ToString());
+#else
                     PropertyName newExposedName = new PropertyName(UnityEditor.GUID.Generate().ToString());
+#endif
                     p_propertyTable.SetReferenceValue(newExposedName, exposedValue);
                     clonedExposedRef.GetType().GetField("exposedName")
                         .SetValue(clonedExposedRef, newExposedName);


### PR DESCRIPTION
Add compatibility shims so the package compiles on Unity 6000.4+, which deprecates InstanceID-based APIs in favor of EntityId.
  
  - `DashEditorConfig`: `enteringPlayModeController` now stores an `EntityId` (via `GetEntityId()`/`EntityIdToObject`) on 6000.4+, falling back to `int`/`InstanceID` otherwise
  - `DashGraphAssetHandler`: `OnOpenAsset` callback accepts `EntityId` on 6000.5+ instead of `int`
  - `NodeModelBase`: uses `UnityEngine.GUID` on 6000.4+ instead of `UnityEditor.GUID`
    
All `#else` branches are untouched, so behavior on older Unity versions is unchanged. No functional changes on either path.