### PR TITLE
Speed up editor domain reloads

### DIFF
--- a/Editor/Scripts/DashEditorCore.cs
+++ b/Editor/Scripts/DashEditorCore.cs
@@ -8,7 +8,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using OdinSerializer.Utilities;
 using UnityEditor;
 using UnityEngine;
@@ -49,8 +48,8 @@ namespace Dash.Editor
 
         static DashEditorCore()
         {
-            SetExecutionOrder(typeof(DashVariablesController), -501);
-            SetExecutionOrder(typeof(DashController), -500);
+            SetExecutionOrder("Packages/com.shtif.dash/Runtime/Scripts/Variables/DashVariablesController.cs", -501);
+            SetExecutionOrder("Packages/com.shtif.dash/Runtime/Scripts/DashController.cs", -500);
 
             EditorConfig = DashEditorConfig.Create();
             RuntimeConfig = DashRuntimeConfig.Create();
@@ -114,16 +113,19 @@ namespace Dash.Editor
             }
         }
 
-        static void SetExecutionOrder(Type p_classType, int p_order)
+        static void SetExecutionOrder(string p_scriptPath, int p_order)
         {
-            MonoScript[] scripts = (MonoScript[])Resources.FindObjectsOfTypeAll(typeof(MonoScript));
-            
-            MonoScript classScript = scripts.First(s => s.GetClass() == p_classType);
+            MonoScript script = AssetDatabase.LoadAssetAtPath<MonoScript>(p_scriptPath);
+            if (!script)
+            {
+                Debug.LogWarning($"[Dash] Could not find script at path '{p_scriptPath}' to set execution order.");
+                return;
+            }
 
             // We need to check the order first and set only if different otherwise we may get into infinity reload assembly loop.
-            if (MonoImporter.GetExecutionOrder(classScript) != p_order)
+            if (MonoImporter.GetExecutionOrder(script) != p_order)
             {
-                MonoImporter.SetExecutionOrder(classScript, p_order);
+                MonoImporter.SetExecutionOrder(script, p_order);
             }
         }
 

--- a/Editor/Scripts/DashEditorCore.cs
+++ b/Editor/Scripts/DashEditorCore.cs
@@ -30,8 +30,20 @@ namespace Dash.Editor
         static public GUISkin Skin => (GUISkin)Resources.Load("Skins/EditorSkins/NodeEditorSkin");
 
         //static public bool DetailsVisible => EditorConfig.zoom < 2.5;
-        
-        static public List<DashGraph> GraphAssets { get; private set; }
+
+        static private List<DashGraph> _graphAssets;
+
+        static public List<DashGraph> GraphAssets
+        {
+            get
+            {
+                if (_graphAssets == null)
+                {
+                    ScanGraphAssets();
+                }
+                return _graphAssets;
+            }
+        }
 
         static public string propertyReference;
 
@@ -44,10 +56,8 @@ namespace Dash.Editor
             RuntimeConfig = DashRuntimeConfig.Create();
             
             Previewer = new DashEditorPreviewer();
-            
-            CheckDashVersion();
 
-            ScanGraphAssets();
+            CheckDashVersion();
 
             SetDefineSymbols();
 
@@ -80,7 +90,7 @@ namespace Dash.Editor
 
         public static void ScanGraphAssets()
         {
-            GraphAssets = AssetUtils.FindAllAssetsByType<DashGraph>();
+            _graphAssets = AssetUtils.FindAllAssetsByType<DashGraph>();
         }
 
         static void CheckDashVersion()


### PR DESCRIPTION
Reduces domain reload time by removing two expensive operations from `DashEditorCore` static constructor:

- **Lazy-load graph assets:** `GraphAssets` no longer scans and loads every graph asset on each domain reload. The collection is now populated on first access via the `GraphAssets` getter.
- **Optimize execution-order setup:** `SetExecutionOrder` now loads the required script directly from its known path using `AssetDatabase.LoadAssetAtPath`, instead of using `Resources.FindObjectsOfTypeAll`, which loads every `MonoScript` in the project.

There is no behavior change as this only avoids unnecessary work during domain reloads.